### PR TITLE
Enhance Time Control UI with Interactive Panel Interface

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -580,3 +580,21 @@ impl Default for StatisticsToggle {
         }
     }
 }
+
+/// UI components for time control panel
+#[derive(Component)]
+pub struct TimeControlPanel;
+
+/// Component for play/pause button
+#[derive(Component)]
+pub struct PlayPauseButton;
+
+/// Component for speed control buttons
+#[derive(Component)]
+pub struct SpeedButton {
+    pub target_speed: f32,
+}
+
+/// Component for speed display text
+#[derive(Component)]
+pub struct SpeedDisplay;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,11 @@ impl Plugin for AntNestPlugin {
                     systems::update_disaster_status_system,
                     systems::update_cooldown_timers_system,
                     systems::disaster_trigger_feedback_system,
+                    // UI systems
+                    systems::time_control_input_system,
+                    systems::update_speed_display_system,
+                    systems::update_play_pause_button_system,
+                    systems::button_click_system,
                     systems::update_active_disasters_display,
                     systems::update_disaster_progress_bars,
                     systems::update_disaster_duration_text,

--- a/src/systems/time_control.rs
+++ b/src/systems/time_control.rs
@@ -1,54 +1,135 @@
-use crate::components::TimeControl;
+use crate::components::{TimeControl, TimeControlPanel, PlayPauseButton, SpeedButton, SpeedDisplay};
 use bevy::prelude::*;
 
-/// UI components for time control
-#[derive(Component)]
-pub struct TimeControlUI;
-
-#[derive(Component)]
-pub struct SpeedDisplay;
-
-/// Setup time control UI
+/// Setup time control UI panel
 pub fn setup_time_control_ui(mut commands: Commands) {
-    // UI Root
+    // Main time control panel container - positioned at top-left
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
-                justify_content: JustifyContent::FlexStart,
-                align_items: AlignItems::FlexStart,
+                position_type: PositionType::Absolute,
+                left: Val::Px(10.0),
+                top: Val::Px(10.0),
+                width: Val::Px(260.0),
                 flex_direction: FlexDirection::Column,
-                padding: UiRect::all(Val::Px(10.0)),
+                padding: UiRect::all(Val::Px(15.0)),
+                row_gap: Val::Px(10.0),
                 ..default()
             },
+            background_color: Color::srgba(0.0, 0.0, 0.0, 0.8).into(),
+            border_radius: BorderRadius::all(Val::Px(8.0)),
             ..default()
         })
         .with_children(|parent| {
+            // Panel title
+            parent.spawn(TextBundle::from_section(
+                "Time Control",
+                TextStyle {
+                    font_size: 20.0,
+                    color: Color::WHITE,
+                    ..default()
+                },
+            ));
+
             // Speed display
             parent.spawn((
                 TextBundle::from_section(
                     "Speed: 1.0x",
                     TextStyle {
-                        font_size: 24.0,
-                        color: Color::WHITE,
+                        font_size: 18.0,
+                        color: Color::srgb(0.8, 1.0, 0.8),
                         ..default()
                     },
                 ),
                 SpeedDisplay,
             ));
 
-            // Controls instruction
+            // Play/Pause button
+            parent
+                .spawn(ButtonBundle {
+                    style: Style {
+                        width: Val::Percent(100.0),
+                        height: Val::Px(40.0),
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    background_color: Color::srgba(0.2, 0.6, 0.2, 0.8).into(),
+                    border_radius: BorderRadius::all(Val::Px(4.0)),
+                    ..default()
+                })
+                .with_children(|button_parent| {
+                    button_parent.spawn(TextBundle::from_section(
+                        "▶ Playing (SPACE to pause)",
+                        TextStyle {
+                            font_size: 16.0,
+                            color: Color::WHITE,
+                            ..default()
+                        },
+                    ));
+                })
+                .insert(PlayPauseButton);
+
+            // Speed control section
             parent.spawn(TextBundle::from_section(
-                "Controls: SPACE=Pause, 1-9=Speed presets, 0=Normal speed",
+                "Speed Presets:",
                 TextStyle {
-                    font_size: 16.0,
-                    color: Color::srgb(0.8, 0.8, 0.8),
+                    font_size: 14.0,
+                    color: Color::srgb(0.9, 0.9, 0.9),
+                    ..default()
+                },
+            ));
+
+            // Speed buttons grid
+            let speed_presets = [
+                (1.0, "1x (Key: 1)"),
+                (2.0, "2x (Key: 2)"),
+                (5.0, "5x (Key: 3)"),
+                (10.0, "10x (Key: 4)"),
+                (20.0, "20x (Key: 5)"),
+                (50.0, "50x (Key: 7)"),
+                (100.0, "Max (Key: 9)"),
+            ];
+
+            for (speed, label) in speed_presets.iter() {
+                parent
+                    .spawn(ButtonBundle {
+                        style: Style {
+                            width: Val::Percent(100.0),
+                            height: Val::Px(32.0),
+                            justify_content: JustifyContent::Center,
+                            align_items: AlignItems::Center,
+                            margin: UiRect::bottom(Val::Px(2.0)),
+                            ..default()
+                        },
+                        background_color: Color::srgba(0.3, 0.3, 0.3, 0.6).into(),
+                        border_radius: BorderRadius::all(Val::Px(4.0)),
+                        ..default()
+                    })
+                    .with_children(|speed_parent| {
+                        speed_parent.spawn(TextBundle::from_section(
+                            *label,
+                            TextStyle {
+                                font_size: 14.0,
+                                color: Color::WHITE,
+                                ..default()
+                            },
+                        ));
+                    })
+                    .insert(SpeedButton { target_speed: *speed });
+            }
+
+            // Instructions
+            parent.spawn(TextBundle::from_section(
+                "Click buttons or use keyboard shortcuts",
+                TextStyle {
+                    font_size: 12.0,
+                    color: Color::srgb(0.7, 0.7, 0.7),
                     ..default()
                 },
             ));
         })
-        .insert(TimeControlUI);
+        .insert(TimeControlPanel);
 }
 
 /// Handle keyboard input for time control
@@ -139,8 +220,69 @@ pub fn update_speed_display_system(
     if let Ok(mut text) = speed_display_query.get_single_mut() {
         if time_control.is_paused {
             text.sections[0].value = "Speed: PAUSED".to_string();
+            text.sections[0].style.color = Color::srgb(1.0, 0.6, 0.6);
         } else {
             text.sections[0].value = format!("Speed: {:.1}x", time_control.speed_multiplier);
+            text.sections[0].style.color = Color::srgb(0.8, 1.0, 0.8);
+        }
+    }
+}
+
+/// Update play/pause button display
+pub fn update_play_pause_button_system(
+    time_control: Res<TimeControl>,
+    mut button_query: Query<&mut Text, (With<Node>, Without<SpeedDisplay>)>,
+    play_pause_query: Query<&Children, With<PlayPauseButton>>,
+) {
+    if let Ok(children) = play_pause_query.get_single() {
+        for &child in children.iter() {
+            if let Ok(mut text) = button_query.get_mut(child) {
+                if time_control.is_paused {
+                    text.sections[0].value = "▶ Paused (SPACE to play)".to_string();
+                } else {
+                    text.sections[0].value = "⏸ Playing (SPACE to pause)".to_string();
+                }
+            }
+        }
+    }
+}
+
+/// Handle mouse clicks on UI buttons
+pub fn button_click_system(
+    mut interaction_query: Query<
+        (&Interaction, &mut BackgroundColor, Option<&SpeedButton>, Option<&PlayPauseButton>),
+        (Changed<Interaction>, With<Button>),
+    >,
+    mut time_control: ResMut<TimeControl>,
+) {
+    for (interaction, mut color, speed_button, play_pause_button) in &mut interaction_query {
+        match *interaction {
+            Interaction::Pressed => {
+                if let Some(speed_button) = speed_button {
+                    // Speed button clicked
+                    time_control.speed_multiplier = speed_button.target_speed;
+                    time_control.is_paused = false;
+                    info!("Speed set to {}x via button click", speed_button.target_speed);
+                } else if play_pause_button.is_some() {
+                    // Play/pause button clicked
+                    time_control.is_paused = !time_control.is_paused;
+                    if time_control.is_paused {
+                        info!("Simulation paused via button click");
+                    } else {
+                        info!("Simulation resumed via button click at {}x speed", time_control.speed_multiplier);
+                    }
+                }
+            }
+            Interaction::Hovered => {
+                *color = Color::srgba(0.5, 0.5, 0.5, 0.8).into();
+            }
+            Interaction::None => {
+                if speed_button.is_some() {
+                    *color = Color::srgba(0.3, 0.3, 0.3, 0.6).into();
+                } else if play_pause_button.is_some() {
+                    *color = Color::srgba(0.2, 0.6, 0.2, 0.8).into();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR enhances the Time Control UI from a simple text-only display to a comprehensive, interactive panel interface that improves user experience and accessibility.

## Key Changes
- **Interactive Panel Design**: Replaced basic text display with a professional panel interface positioned at top-left
- **Clickable Controls**: Added fully interactive play/pause button with clear visual state indicators (▶/⏸)
- **Speed Preset Buttons**: Implemented clickable speed control buttons for common presets (1x, 2x, 5x, 10x, 20x, 50x, 100x)
- **Visual Feedback**: Added hover effects and background color changes for all interactive elements
- **Dual Control Support**: Maintained existing keyboard shortcuts while adding mouse controls
- **Consistent Styling**: Matched design patterns from existing disaster control panel

## Technical Implementation
- Added new UI components: `TimeControlPanel`, `PlayPauseButton`, `SpeedButton`
- Implemented button interaction systems with proper state management
- Enhanced speed display with color-coded status (green for active, red for paused)
- Integrated with existing ECS architecture and time control logic

## User Experience Improvements
- ✅ Clear visual hierarchy with labeled sections
- ✅ Intuitive button layouts with keyboard shortcut hints
- ✅ Real-time status updates for current speed and play/pause state
- ✅ Hover effects provide immediate visual feedback
- ✅ Consistent with overall application design language

## Testing
- ✅ Code compiles without errors
- ✅ All existing keyboard shortcuts remain functional
- ✅ Button interactions properly update simulation state
- ✅ Visual states update correctly based on simulation status

## Accessibility
- Keyboard shortcuts preserved for users who prefer keyboard navigation
- Clear labeling and visual indicators for current state
- High contrast colors for readability

This addresses part of **Issue #37**: UI/UX improvements for better user experience.

🤖 Generated with [Claude Code](https://claude.ai/code)