### PR TITLE
Fix Bevy ECS Query System Conflict in Ant Movement System

### DIFF
--- a/src/systems/movement.rs
+++ b/src/systems/movement.rs
@@ -20,7 +20,7 @@ pub fn ant_movement_system(
             &mut Lifecycle,
             &mut Inventory,
         ),
-        With<Ant>,
+        (With<Ant>, Without<Food>),
     >,
     food_query: Query<(&Position, &FoodSource), With<Food>>,
     invasive_query: Query<&Position, With<InvasiveSpecies>>,


### PR DESCRIPTION
## Summary
- Fixes critical startup crash caused by Bevy ECS query system conflict
- Resolves issue #78 where `ant_movement_system` and `food_consumption_system` were accessing Position component with conflicting mutability

## Changes
- Added `Without<Food>` filter to ant query in `ant_movement_system`
- This ensures disjoint queries that don't interfere with each other
- Single line change that prevents ECS borrow checker conflicts

## Test Plan
- [x] Compile check: `cargo build --release` succeeds
- [x] Test execution: `cargo test` passes  
- [x] Application no longer crashes with query conflict error
- [ ] Manual testing on Windows platform (after merge)

## Technical Details
**Root Cause**: Two systems accessing Position component simultaneously:
- `ant_movement_system`: `&mut Position` (mutable)
- `food_consumption_system`: `&Position` (immutable)

**Solution**: Use Bevy's `Without<T>` filter to create disjoint entity sets, preventing query conflicts.

**Impact**: Critical bug fix - application was completely unusable due to startup crash.

🤖 Generated with [Claude Code](https://claude.ai/code)