### PR TITLE
Fix ECS query conflict in invasive species system

### DIFF
--- a/src/systems/movement.rs
+++ b/src/systems/movement.rs
@@ -23,7 +23,7 @@ pub fn ant_movement_system(
         (With<Ant>, Without<Food>),
     >,
     food_query: Query<(&Position, &FoodSource), With<Food>>,
-    invasive_query: Query<&Position, With<InvasiveSpecies>>,
+    invasive_query: Query<&Position, (With<InvasiveSpecies>, Without<Ant>)>,
 ) {
     let mut rng = thread_rng();
 


### PR DESCRIPTION
## Summary
- Fix runtime panic caused by ECS query conflict in ant_movement_system
- Add `Without<Ant>` filter to invasive_query to prevent Position component access conflicts
- Resolves B0001 error that was preventing Windows users from running the application

## Test plan
- [x] Verified cargo fmt passes
- [x] Verified cargo clippy passes  
- [x] Verified cargo test passes
- [x] Verified cargo build --release succeeds
- [ ] Test runtime execution on Windows

🤖 Generated with [Claude Code](https://claude.ai/code)